### PR TITLE
Add pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,45 @@ NOTE: In order to run this on your own machine, you will need a copy of the Ark 
 
 ## Endpoints
 
-### `GET /search/:search-term`
+### `GET /search`
+
+<details>
+  <summary>Query parameters</summary>
+
+  #### `query`
+
+  The product you're searching for
+  ```
+  Type: string
+  Array: false
+  Required: true
+  ```
+
+  #### `count`
+
+  Determines the max amount of results to be returned by the API
+  ```
+  Type: integer
+  Default: 50
+  Min: 1
+  Max: 50
+  Array: false
+  Required: false
+  ```
+
+  #### `firstRecord`
+
+  Determines the index of the first record to be returned by the API, relative to the length of the results from the DB
+  ```
+  Type: integer
+  Default: 0
+  Min: 0
+  Max: 9223372036854775807
+  Array: false
+  Required: false
+  ```
+
+</details>
 
 <details>
   <summary>Response schema</summary>
@@ -74,299 +112,88 @@ NOTE: In order to run this on your own machine, you will need a copy of the Ark 
   <summary>Example response</summary>
 
   ```json
-  [
-    {
-      "id": 52210,
-      "name": "Intel® Core™ i5-2500K Processor (6M Cache, up to 3.70 GHz)",
-      "specs": [
-        [
-          "Advanced Technologies",
-          "Enhanced Intel SpeedStep® Technology",
-          "Yes"
-        ],
-        [
-          "Advanced Technologies",
-          "Idle States",
-          "Yes"
-        ],
-        [
-          "Advanced Technologies",
-          "Instruction Set",
-          "64-bit"
-        ],
-        [
-          "Advanced Technologies",
-          "Instruction Set Extensions",
-          "Intel® SSE4.1, Intel® SSE4.2, Intel® AVX"
-        ],
-        [
-          "Advanced Technologies",
-          "Intel vPro® Platform Eligibility <small><sup>‡</sup></small>",
-          "No"
-        ],
-        [
-          "Advanced Technologies",
-          "Intel® 64 <small><sup>‡</sup></small>",
-          "Yes"
-        ],
-        [
-          "Advanced Technologies",
-          "Intel® Fast Memory Access",
-          "Yes"
-        ],
-        [
-          "Advanced Technologies",
-          "Intel® Flex Memory Access",
-          "Yes"
-        ],
-        [
-          "Advanced Technologies",
-          "Intel® Hyper-Threading Technology <small><sup>‡</sup></small>",
-          "No"
-        ],
-        [
-          "Advanced Technologies",
-          "Intel® Identity Protection Technology <small><sup>‡</sup></small>",
-          "Yes"
-        ],
-        [
-          "Advanced Technologies",
-          "Intel® Turbo Boost Technology <small><sup>‡</sup></small>",
-          "2.0"
-        ],
-        [
-          "Advanced Technologies",
-          "Intel® Virtualization Technology (VT-x) <small><sup>‡</sup></small>",
-          "Yes"
-        ],
-        [
-          "Advanced Technologies",
-          "Intel® Virtualization Technology for Directed I/O (VT-d) <small><sup>‡</sup></small>",
-          "No"
-        ],
-        [
-          "Advanced Technologies",
-          "Intel® VT-x with Extended Page Tables (EPT) <small><sup>‡</sup></small>",
-          "Yes"
-        ],
-        [
-          "Advanced Technologies",
-          "Thermal Monitoring Technologies",
-          "Yes"
-        ],
-        [
-          "CPU Specifications",
-          "# of Cores",
-          "4"
-        ],
-        [
-          "CPU Specifications",
-          "# of Threads",
-          "4"
-        ],
-        [
-          "CPU Specifications",
-          "Bus Speed",
-          "5 GT/s"
-        ],
-        [
-          "CPU Specifications",
-          "Cache",
-          "6 MB Intel® Smart Cache"
-        ],
-        [
-          "CPU Specifications",
-          "Intel® Turbo Boost Technology 2.0 Frequency<small><sup>‡</sup></small>",
-          "3.70 GHz"
-        ],
-        [
-          "CPU Specifications",
-          "Max Turbo Frequency",
-          "3.70 GHz"
-        ],
-        [
-          "CPU Specifications",
-          "Processor Base Frequency",
-          "3.30 GHz"
-        ],
-        [
-          "CPU Specifications",
-          "TDP",
-          "95 W"
-        ],
-        [
-          "Essentials",
-          "Code Name",
-          "Products formerly Sandy Bridge"
-        ],
-        [
-          "Essentials",
-          "Expected Discontinuance",
-          "Q1'13"
-        ],
-        [
-          "Essentials",
-          "Launch Date",
-          "Q1'11"
-        ],
-        [
-          "Essentials",
-          "Lithography",
-          "32 nm"
-        ],
-        [
-          "Essentials",
-          "Off Roadmap",
-          "No"
-        ],
-        [
-          "Essentials",
-          "Processor Number",
-          "i5-2500K"
-        ],
-        [
-          "Essentials",
-          "Product Collection",
-          "Legacy Intel® Core™ Processors"
-        ],
-        [
-          "Essentials",
-          "Status",
-          "Discontinued"
-        ],
-        [
-          "Essentials",
-          "Vertical Segment",
-          "Desktop"
-        ],
-        [
-          "Expansion Options",
-          "Max # of PCI Express Lanes",
-          "16"
-        ],
-        [
-          "Expansion Options",
-          "PCI Express Revision",
-          "2.0"
-        ],
-        [
-          "Memory Specifications",
-          "ECC Memory Supported   <small><sup>‡</sup></small>",
-          "No"
-        ],
-        [
-          "Memory Specifications",
-          "Max # of Memory Channels",
-          "2"
-        ],
-        [
-          "Memory Specifications",
-          "Max Memory Bandwidth",
-          "21 GB/s"
-        ],
-        [
-          "Memory Specifications",
-          "Max Memory Size (dependent on memory type)",
-          "32 GB"
-        ],
-        [
-          "Memory Specifications",
-          "Memory Types",
-          "DDR3 1066/1333"
-        ],
-        [
-          "Package Specifications",
-          "Max CPU Configuration",
-          "1"
-        ],
-        [
-          "Package Specifications",
-          "Package Size",
-          "37.5mm x 37.5mm"
-        ],
-        [
-          "Package Specifications",
-          "Sockets Supported",
-          "LGA1155"
-        ],
-        [
-          "Package Specifications",
-          "T<sub>CASE</sub>",
-          "72.6°C"
-        ],
-        [
-          "Processor Graphics",
-          "# of Displays Supported <small><sup>‡</sup></small>",
-          "2"
-        ],
-        [
-          "Processor Graphics",
-          "Device ID",
-          "0x112"
-        ],
-        [
-          "Processor Graphics",
-          "Graphics Base Frequency",
-          "850 MHz"
-        ],
-        [
-          "Processor Graphics",
-          "Graphics Max Dynamic Frequency",
-          "1.10 GHz"
-        ],
-        [
-          "Processor Graphics",
-          "Intel® Clear Video HD Technology",
-          "Yes"
-        ],
-        [
-          "Processor Graphics",
-          "Intel® Flexible Display Interface (Intel® FDI)",
-          "Yes"
-        ],
-        [
-          "Processor Graphics",
-          "Intel® InTru™ 3D Technology",
-          "Yes"
-        ],
-        [
-          "Processor Graphics",
-          "Intel® Quick Sync Video",
-          "Yes"
-        ],
-        [
-          "Processor Graphics",
-          "Processor Graphics <small><sup>‡</sup></small>",
-          "Intel® HD Graphics 3000"
-        ],
-        [
-          "Security & Reliability",
-          "Execute Disable Bit <small><sup>‡</sup></small>",
-          "Yes"
-        ],
-        [
-          "Security & Reliability",
-          "Intel® AES New Instructions",
-          "Yes"
-        ],
-        [
-          "Security & Reliability",
-          "Intel® Trusted Execution Technology <small><sup>‡</sup></small>",
-          "No"
-        ],
-        [
-          "Supplemental Information",
-          "Datasheet",
-          "http://www.intel.com/content/www/us/en/processors/core/CoreTechnicalResources.html"
-        ],
-        [
-          "Supplemental Information",
-          "Embedded Options Available",
-          "No"
+  {
+    "totalRecords": 10,
+    "firstRecord": 3,
+    "products": [
+      {
+        "id": 52210,
+        "name": "Intel® Core™ i5-2500K Processor (6M Cache, up to 3.70 GHz)",
+        "specs": [
+          [
+            "Advanced Technologies",
+            "Intel® 64 <small><sup>‡</sup></small>",
+            "Yes"
+          ],
+          [
+            "Advanced Technologies",
+            "Intel® Hyper-Threading Technology <small><sup>‡</sup></small>",
+            "No"
+          ],
+          [
+            "Advanced Technologies",
+            "Intel® Virtualization Technology for Directed I/O (VT-d) <small><sup>‡</sup></small>",
+            "No"
+          ],
+          [
+            "CPU Specifications",
+            "# of Cores",
+            "4"
+          ],
+          [
+            "CPU Specifications",
+            "# of Threads",
+            "4"
+          ],
+          [
+            "CPU Specifications",
+            "Cache",
+            "6 MB Intel® Smart Cache"
+          ],
+          [
+            "CPU Specifications",
+            "Intel® Turbo Boost Technology 2.0 Frequency<small><sup>‡</sup></small>",
+            "3.70 GHz"
+          ],
+          [
+            "CPU Specifications",
+            "Max Turbo Frequency",
+            "3.70 GHz"
+          ],
+          [
+            "CPU Specifications",
+            "Processor Base Frequency",
+            "3.30 GHz"
+          ],
+          [
+            "CPU Specifications",
+            "TDP",
+            "95 W"
+          ],
+          [
+            "Essentials",
+            "Code Name",
+            "Products formerly Sandy Bridge"
+          ],
+          [
+            "Essentials",
+            "Expected Discontinuance",
+            "Q1'13"
+          ],
+          [
+            "Essentials",
+            "Launch Date",
+            "Q1'11"
+          ],
+          [
+            "Essentials",
+            "Lithography",
+            "32 nm"
+          ]
         ]
-      ]
-    }
-  ]
+      }
+    ]
+  }
   ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -15,30 +15,53 @@ NOTE: In order to run this on your own machine, you will need a copy of the Ark 
 
   ```json
   {
-    "type": "array",
-    "default": [],
-    "items": {
-      "type": "object",
-      "required": [
-        "id",
-        "name",
-        "specs"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "specs": {
-          "type": "array",
-          "items": {
+    "$schema": "http://json-schema.org/schema",
+    "$defs": {
+      "product": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "specs"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer",
+            "description": "The ID of the product, as represented on the Ark website. This can be used to generate a URL for this product on the Ark website"
+          },
+          "specs": {
             "type": "array",
+            "minItems": 3,
+            "maxItems": 3,
+            "description": "Each array within the array contains three string values. The first value is the spec category - the second value is the spec key - and the third value is the spec value",
             "items": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
+        }
+      }
+    },
+    "type": "object",
+    "properties": {
+      "totalRecords": {
+        "type": "integer",
+        "description": "How many records were retrieved by the whole search. Note that the amount of records contained in the products array may be smaller. This value is present for pagination purposes"
+      },
+      "firstRecord": {
+        "type": "integer",
+        "description": "The index of the first record in the products array, relative to the whole search query. This value is present for pagination purposes"
+      },
+      "products": {
+        "type": "array",
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/product"
         }
       }
     }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -112,6 +113,16 @@ func intFromParams(params *url.Values, key string, defaultValue int) int {
 	return defaultValue
 }
 
+func constrainInt(num int, min int, max int) int {
+	if num < min {
+		return min
+	} else if max < num {
+		return max
+	} else {
+		return num
+	}
+}
+
 func initDB() *gorm.DB {
 	new_db, _ := gorm.Open(sqlite.Open("ark-en.sqlite"), &gorm.Config{})
 	return new_db
@@ -120,8 +131,8 @@ func initDB() *gorm.DB {
 func searchHandler(c *gin.Context) {
 	searchTerm := c.Param("search-term")
 	queryParams := c.Request.URL.Query()
-	firstRecord := intFromParams(&queryParams, "firstRecord", 0)
-	count := intFromParams(&queryParams, "count", 50)
+	firstRecord := constrainInt(intFromParams(&queryParams, "firstRecord", 0), 0, math.MaxInt64)
+	count := constrainInt(intFromParams(&queryParams, "count", 50), 1, 50)
 
 	rawProducts := getProductIDs(searchTerm)
 	populatedProducts := make([]populatedProduct, 0)

--- a/main.go
+++ b/main.go
@@ -129,8 +129,8 @@ func initDB() *gorm.DB {
 }
 
 func searchHandler(c *gin.Context) {
-	searchTerm := c.Param("search-term")
 	queryParams := c.Request.URL.Query()
+	searchTerm := queryParams.Get("query")
 	firstRecord := constrainInt(intFromParams(&queryParams, "firstRecord", 0), 0, math.MaxInt64)
 	count := constrainInt(intFromParams(&queryParams, "count", 50), 1, 50)
 
@@ -155,6 +155,6 @@ func searchHandler(c *gin.Context) {
 func main() {
 	db = initDB()
 	router := gin.Default()
-	router.GET("/search/:search-term", searchHandler)
+	router.GET("/search", searchHandler)
 	router.Run("localhost:8000")
 }


### PR DESCRIPTION
Resolves #1

- Added query parameters `count` and `firstRecord` to the search endpoint for pagination reasons
- Moved the search term on the search endpoint to a query parameter `query`
- Moved the search endpoint from `/search/:search-term` to `/search`
- Added response type with extra metadata
- Added documentation for the above