### PR TITLE
Use link header for pagination metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,26 +22,14 @@ NOTE: In order to run this on your own machine, you will need a copy of the Ark 
   Required: true
   ```
 
-  #### `count`
+  #### `page`
 
-  Determines the max amount of results to be returned by the API
+  The page number to fetch. Pages are 50 items long
   ```
   Type: integer
-  Default: 50
+  Default: 1
   Min: 1
-  Max: 50
-  Array: false
-  Required: false
-  ```
-
-  #### `firstRecord`
-
-  Determines the index of the first record to be returned by the API, relative to the length of the results from the DB
-  ```
-  Type: integer
-  Default: 0
-  Min: 0
-  Max: 9223372036854775807
+  Max: max int64
   Array: false
   Required: false
   ```
@@ -85,23 +73,10 @@ NOTE: In order to run this on your own machine, you will need a copy of the Ark 
         }
       }
     },
-    "type": "object",
-    "properties": {
-      "totalRecords": {
-        "type": "integer",
-        "description": "How many records were retrieved by the whole search. Note that the amount of records contained in the products array may be smaller. This value is present for pagination purposes"
-      },
-      "firstRecord": {
-        "type": "integer",
-        "description": "The index of the first record in the products array, relative to the whole search query. This value is present for pagination purposes"
-      },
-      "products": {
-        "type": "array",
-        "default": [],
-        "items": {
-          "$ref": "#/$defs/product"
-        }
-      }
+    "type": "array",
+    "default": [],
+    "items": {
+      "$ref": "#/$defs/product"
     }
   }
   ```
@@ -112,88 +87,91 @@ NOTE: In order to run this on your own machine, you will need a copy of the Ark 
   <summary>Example response</summary>
 
   ```json
-  {
-    "totalRecords": 10,
-    "firstRecord": 3,
-    "products": [
-      {
-        "id": 52210,
-        "name": "Intel® Core™ i5-2500K Processor (6M Cache, up to 3.70 GHz)",
-        "specs": [
-          [
-            "Advanced Technologies",
-            "Intel® 64 <small><sup>‡</sup></small>",
-            "Yes"
-          ],
-          [
-            "Advanced Technologies",
-            "Intel® Hyper-Threading Technology <small><sup>‡</sup></small>",
-            "No"
-          ],
-          [
-            "Advanced Technologies",
-            "Intel® Virtualization Technology for Directed I/O (VT-d) <small><sup>‡</sup></small>",
-            "No"
-          ],
-          [
-            "CPU Specifications",
-            "# of Cores",
-            "4"
-          ],
-          [
-            "CPU Specifications",
-            "# of Threads",
-            "4"
-          ],
-          [
-            "CPU Specifications",
-            "Cache",
-            "6 MB Intel® Smart Cache"
-          ],
-          [
-            "CPU Specifications",
-            "Intel® Turbo Boost Technology 2.0 Frequency<small><sup>‡</sup></small>",
-            "3.70 GHz"
-          ],
-          [
-            "CPU Specifications",
-            "Max Turbo Frequency",
-            "3.70 GHz"
-          ],
-          [
-            "CPU Specifications",
-            "Processor Base Frequency",
-            "3.30 GHz"
-          ],
-          [
-            "CPU Specifications",
-            "TDP",
-            "95 W"
-          ],
-          [
-            "Essentials",
-            "Code Name",
-            "Products formerly Sandy Bridge"
-          ],
-          [
-            "Essentials",
-            "Expected Discontinuance",
-            "Q1'13"
-          ],
-          [
-            "Essentials",
-            "Launch Date",
-            "Q1'11"
-          ],
-          [
-            "Essentials",
-            "Lithography",
-            "32 nm"
-          ]
+  [
+    {
+      "id": 52210,
+      "name": "Intel® Core™ i5-2500K Processor (6M Cache, up to 3.70 GHz)",
+      "specs": [
+        [
+          "Advanced Technologies",
+          "Intel® 64 <small><sup>‡</sup></small>",
+          "Yes"
+        ],
+        [
+          "Advanced Technologies",
+          "Intel® Hyper-Threading Technology <small><sup>‡</sup></small>",
+          "No"
+        ],
+        [
+          "Advanced Technologies",
+          "Intel® Virtualization Technology for Directed I/O (VT-d) <small><sup>‡</sup></small>",
+          "No"
+        ],
+        [
+          "CPU Specifications",
+          "# of Cores",
+          "4"
+        ],
+        [
+          "CPU Specifications",
+          "# of Threads",
+          "4"
+        ],
+        [
+          "CPU Specifications",
+          "Cache",
+          "6 MB Intel® Smart Cache"
+        ],
+        [
+          "CPU Specifications",
+          "Intel® Turbo Boost Technology 2.0 Frequency<small><sup>‡</sup></small>",
+          "3.70 GHz"
+        ],
+        [
+          "CPU Specifications",
+          "Max Turbo Frequency",
+          "3.70 GHz"
+        ],
+        [
+          "CPU Specifications",
+          "Processor Base Frequency",
+          "3.30 GHz"
+        ],
+        [
+          "CPU Specifications",
+          "TDP",
+          "95 W"
+        ],
+        [
+          "Essentials",
+          "Code Name",
+          "Products formerly Sandy Bridge"
+        ],
+        [
+          "Essentials",
+          "Expected Discontinuance",
+          "Q1'13"
+        ],
+        [
+          "Essentials",
+          "Launch Date",
+          "Q1'11"
+        ],
+        [
+          "Essentials",
+          "Lithography",
+          "32 nm"
         ]
-      }
-    ]
-  }
+      ]
+    }
+  ]
   ```
 
 </details>
+
+## Pagination
+
+On endpoints that support pagination, you can specify a page number by using the `page` query parameter.
+Pages are numbered starting from 1. If you pass in a number outside of the bounds of the amount of pages in the result, it will default to the maximum or minimum page, depending on which direction your page number was out of bounds by.
+
+Pagination information is contained within the [link header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link) in the API response. No link header will be sent if a search only yields 1 page


### PR DESCRIPTION
- Moved response metadata regarding pagination to the link header
- Updated docs